### PR TITLE
Fix JavaScript syntax error in timer component

### DIFF
--- a/pass_j_application_locale_offline - Copie (2) (4).html
+++ b/pass_j_application_locale_offline - Copie (2) (4).html
@@ -745,7 +745,7 @@
         // Cacher les champs de saisie du temps
         $('.time-setter').style.display='none';
       }
-    },}
+    }
   };
 
   function setupDrag(){


### PR DESCRIPTION
## Summary
- remove extraneous comma/brace from timer `updateUI` function that caused `Unexpected token ';'`

## Testing
- `node --check script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689b81342bd88332aebc85693871edc5